### PR TITLE
add_send_text_message

### DIFF
--- a/vapi_python/daily_call.py
+++ b/vapi_python/daily_call.py
@@ -1,6 +1,7 @@
 import daily
 import threading
 import pyaudio
+import json
 
 SAMPLE_RATE = 16000
 NUM_CHANNELS = 1
@@ -160,3 +161,15 @@ class DailyCall(daily.EventHandler):
 
             if len(buffer) > 0:
                 self.__output_audio_stream.write(buffer, CHUNK_SIZE)
+
+    def send_app_message(self, message):
+        """
+        Send an application message to the assistant.
+
+        :param message: The message to send.
+        """
+        try:
+            serialized_message = json.dumps(message)
+            self.__call_client.send_app_message(serialized_message)
+        except Exception as e:
+            print(f"Failed to send app message: {e}")

--- a/vapi_python/daily_call.py
+++ b/vapi_python/daily_call.py
@@ -169,9 +169,6 @@ class DailyCall(daily.EventHandler):
         :param message: The message to send (expects a dictionary).
         """
         try:
-            if not isinstance(message, dict):
-                raise ValueError("Message must be a dictionary.")
-
             serialized_message = json.dumps(message)
             self.__call_client.send_app_message(serialized_message)
         except Exception as e:

--- a/vapi_python/daily_call.py
+++ b/vapi_python/daily_call.py
@@ -166,9 +166,12 @@ class DailyCall(daily.EventHandler):
         """
         Send an application message to the assistant.
 
-        :param message: The message to send.
+        :param message: The message to send (expects a dictionary).
         """
         try:
+            if not isinstance(message, dict):
+                raise ValueError("Message must be a dictionary.")
+
             serialized_message = json.dumps(message)
             self.__call_client.send_app_message(serialized_message)
         except Exception as e:

--- a/vapi_python/vapi_python.py
+++ b/vapi_python/vapi_python.py
@@ -63,20 +63,33 @@ class Vapi:
         self.__client.leave()
         self.__client = None
 
-    def send(self, message_type, message_content):
+    def send(self, message):
         """
-        Send a message to the assistant.
+        Send a generic message to the assistant.
 
-        :param message_type: Type of message, such as 'add-message'.
-        :param message_content: The content of the message.
+        :param message: A dictionary containing the message type and content.
         """
         if not self.__client:
             raise Exception("Call not started. Please start the call first.")
 
-        message = {
-            "type": message_type,
-            "message": message_content
-        }
+        # Check message format here instead of serialization
+        if not isinstance(message, dict) or 'type' not in message:
+            raise ValueError("Invalid message format.")
 
-        # Simulate sending a message by calling the appropriate method on the client
-        self.__client.send_app_message(message)
+        try:
+            self.__client.send_app_message(message)  # Send dictionary directly
+        except Exception as e:
+            print(f"Failed to send message: {e}")
+
+    def add_message(self, role, content):
+        """
+        method to send text messages with specific parameters.
+        """
+        message = {
+            'type': 'add-message',
+            'message': {
+                'role': role,
+                'content': content
+            }
+        }
+        self.send(message)

--- a/vapi_python/vapi_python.py
+++ b/vapi_python/vapi_python.py
@@ -62,3 +62,21 @@ class Vapi:
     def stop(self):
         self.__client.leave()
         self.__client = None
+
+    def send(self, message_type, message_content):
+        """
+        Send a message to the assistant.
+
+        :param message_type: Type of message, such as 'add-message'.
+        :param message_content: The content of the message.
+        """
+        if not self.__client:
+            raise Exception("Call not started. Please start the call first.")
+
+        message = {
+            "type": message_type,
+            "message": message_content
+        }
+
+        # Simulate sending a message by calling the appropriate method on the client
+        self.__client.send_app_message(message)


### PR DESCRIPTION
To send text messages to the assistant aside from the audio input using the send method and passing appropriate role and content.

```

vapi = Vapi(api_key=key)

vapi.start(assistant_id='xxx')

time.sleep(5)

vapi.add_message('user', 'Can you explain VAPI in one sentence?')

time.sleep(15)

vapi.stop()


```

We can look at few results here 

https://dashboard.vapi.ai/calls/e40c730f-87dc-42a1-82f0-bce53697150c

https://dashboard.vapi.ai/calls/dd35f893-99dd-4366-a2a8-23c9ac04c5c9


Here is a screenshot of the message from vapi call logs.

![Screenshot 2024-08-21 at 9 38 58 PM](https://github.com/user-attachments/assets/1bba50ba-afd7-4014-9c2f-236fff808a45)


